### PR TITLE
Ajouts des liens internes dans le footer

### DIFF
--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -1,17 +1,17 @@
 ---
 links:
-  - 
+  -
     label: agd.data.gouv.fr
     children:
-      - 
+      -
         label: Données de référence
-        target: 
-      - 
+        target: _pages/page.md
+      -
         label: Condition générales d’utilisation
-        target: 
+        target:
       -
         label: API
-        target: https://www.data.gouv.fr/api
+        url: https://www.data.gouv.fr/api
   -
     children:
       -
@@ -25,18 +25,18 @@ links:
         target:
 
 social:
-  - 
+  -
     icon: mail
-    target: mailto:info@data.gouv.fr
-  - 
+    url: mailto:info@data.gouv.fr
+  -
     icon: twitter
-    target: https://www.twitter.com/datagouvfr
-  - 
+    url: https://www.twitter.com/datagouvfr
+  -
     icon: fb
-    target: https://www.facebook.com/etalab
-  - 
+    url: https://www.facebook.com/etalab
+  -
     icon: github
-    target: https://www.github.com/etalab
-  - 
+    url: https://www.github.com/etalab
+  -
     icon: rss
-    target: https://www.data.gouv.fr/fr/datasets/recent.atom
+    url: https://www.data.gouv.fr/fr/datasets/recent.atom

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,7 +5,7 @@
       {% if site.data.footer.social %}
       <ul class="footer__social">
         {% for item in site.data.footer.social %}
-        <li><a href="{{ item.target }}"><svg class="icon icon-{{ item.icon }}"><use xlink:href="#icon-{{ item.icon }}"></use></svg></a></li>
+        <li><a href="{{ item.url }}"><svg class="icon icon-{{ item.icon }}"><use xlink:href="#icon-{{ item.icon }}"></use></svg></a></li>
         {% endfor %}
       </ul>
       {% endif %}
@@ -13,13 +13,18 @@
     {% for item in site.data.footer.links %}
     <div class="footer__links">
       {% if item.label %}
-      <h2>{{ item.label}}</h2>     
+      <h2>{{ item.label}}</h2>
       {% endif %}
       <ul>
-      {% for link in item.children %}
-      <li><a href="{{ link.target }}">{{ link.label }}</a></li>
-      {% endfor %}
-    </ul>
+        {% for link in item.children %}
+          {% if link.target %}
+            {% assign target = site.pages | where:"path",link.target | first %}
+            <li><a href="{{ target.url }}">{{ link.label }}</a></li>
+          {% elsif link.url %}
+            <li><a href="{{ link.url }}">{{ link.label }}</a></li>
+          {% endif %}
+        {% endfor %}
+      </ul>
     </div>
     {% endfor %}
     <div></div>


### PR DESCRIPTION
Pouvoir faire des liens internes dans le footer.
Afin de faire apparaitre la différence pour la réappropriation, j'ai ajouté un exemple sur le lien "Données de références" qui renvoi vers une page interne.
J'ai rajouté une distinction target (lien interne) et url (lien externe). Par soucis de simplicité dans le fichier, étant donné que les liens "social" sont le plus souvent externe, j'ai changé de target en url pour eux aussi.