### PR TITLE
z-index dropdown menu

### DIFF
--- a/assets/style/main.css
+++ b/assets/style/main.css
@@ -626,7 +626,7 @@ span.navbar__domain {
   right: 0;
   -webkit-box-shadow: 0 8px 16px 0 rgba(0, 0, 0, .2);
           box-shadow: 0 8px 16px 0 rgba(0, 0, 0, .2);
-  z-index: 1;
+  z-index: 90;
 }
 
 .dropdown-content a {
@@ -1618,4 +1618,3 @@ a.article__link:hover {
   border: 1px solid #adb9c9;
   color: #53657d;
 }
-


### PR DESCRIPTION
Avec un z-index à 1, le menu dropdow pouvait passer derrière l'hero image (z-index à 5) et le container dont le tire (z-index à 10). J'ai passé à 90, étant donné que la navbar est à 100.