### PR TITLE
Fix edit link if articles are in a collections folder

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,7 +3,6 @@ layout: default
 ---
 
 {% assign lang = page.lang | default: site.lang | default: "en" %}
-{% assign base_path = site.collections_dir | default: "" | append: "/" %}
 
 <div class="page article">
 {% include hero.html title=page.title %}
@@ -16,7 +15,11 @@ layout: default
         Use the github edit link until netlify-cms support easy deep link.
         See: https://github.com/netlify/netlify-cms/issues/697
     {% endcomment %}
-    <a class="edit-button" href="https://github.com/{{ site.github_repository }}/edit/master{{ base_path }}{{ page.path }}">
+    {% if site.collections_dir == "" or site.collections_dir == nil %}
+      <a class="edit-button" href="https://github.com/{{ site.github_repository }}/edit/master/{{ page.path }}">
+    {% else %}
+      <a class="edit-button" href="https://github.com/{{ site.github_repository }}/edit/master/{{ site.collections_dir }}/{{ page.path }}">
+    {% endif %}
         ✎ {{ site.i18n[lang].edit }}
     </a>
   </div>


### PR DESCRIPTION
Follow up of #11.

I'm not good at Liquid and therefore I missed a case in my previous PR.

I switched to a condition, maybe it's simpler? Whatever you prefer, you're free to change.

The overall logic is
```
if collections_dir is not empty
  base_path = "/" + collections_dir + "/"
else
  base_path = "/"
end
```